### PR TITLE
Change Vue import to lowercase

### DIFF
--- a/dist/draggable.d.ts
+++ b/dist/draggable.d.ts
@@ -1,4 +1,4 @@
-import Vue from "Vue";
+import Vue from "vue";
 export declare type HandleType = Vue | HTMLElement;
 export interface Position {
     left: number;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,1 @@
-export { HandleType, Position, DraggableValue, DraggableBindings, Draggable } from './draggable';
+export { HandleType, Position, DraggableValue, DraggableBindings, Draggable, PositionDiff, MarginOptions } from './draggable';

--- a/dist/index.js.map
+++ b/dist/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;AAAA,yCAMqB;AADjB,gCAAA,SAAS,CAAA"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;AAAA,yCAQqB;AAHjB,gCAAA,SAAS,CAAA"}

--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -1,4 +1,4 @@
-import Vue from "Vue";
+import Vue from "vue";
 
 export type HandleType = Vue | HTMLElement;
 export interface Position {


### PR DESCRIPTION
This package works fine on Mac, but breaks on Linux because the file system is case sensitive.

Error:

```
ERROR in [at-loader] ./src/lib/draggable-vue-directive/draggable.ts:3:17 
TS2307: Cannot find module 'Vue'.
```

Changing the module name to lowercase (`vue`, rather than `Vue`) fixes the issue.