### PR TITLE
preventDefault when mousedown to remove "draggable" side effects

### DIFF
--- a/src/draggable.ts
+++ b/src/draggable.ts
@@ -174,6 +174,7 @@ export const Draggable = {
 		}
 
 		function mouseDown(event: MouseEvent) {
+			event.preventDefault();
 			setState({ initialMousePos: getInitialMousePosition(event) });
 			handlePositionChanged(event, ChangePositionType.Start);
 			document.addEventListener("mousemove", mouseMove);


### PR DESCRIPTION
#18 

fix "draggable" attr side effects.

emmm, it's normal on Chrome version<69, but, there is a problem with Chrome version 69.